### PR TITLE
Switch GitHub Actions builds to devel version of R

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,10 +18,12 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'release'}
-          - {os: windows-latest, r: 'release'}
+#          - {os: macOS-latest,   r: 'release'}
+#          - {os: windows-latest, r: 'release'}
+          - {os: macOS-latest,   r: 'devel'}
+          - {os: windows-latest, r: 'devel'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,   r: 'release'}
+#          - {os: ubuntu-latest,   r: 'release'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,6 +18,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v1
         with:
+          r-version: 'devel'
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v1


### PR DESCRIPTION
To avoid breaking builds after making the `devel` version of R (4.2.0) a dependency.